### PR TITLE
Broken link in docs

### DIFF
--- a/docs/mixed_channel.md
+++ b/docs/mixed_channel.md
@@ -118,4 +118,4 @@ print('Output shape: ', output.sample.shape)
 ### Example Notebook
 
 An example notebook how to run inference for pretrained PDE-Transformer and additional explanations/code examples can be found at 
-[notebooks/visualization_mc_ape2d.ipynb](https://github.com/tum-pbs/pde-transformer/blob/main/pdetransformer/notebooks/visualization_mc_ape2d.ipynb).
+[notebooks/visualization_mc_ape2d.ipynb](https://github.com/tum-pbs/pde-transformer/blob/main/notebooks/visualization_mc_ape2d.ipynb).


### PR DESCRIPTION
The current link https://github.com/tum-pbs/pde-transformer/blob/main/pdetransformer/notebooks/visualization_mc_ape2d.ipynb leads to a 404 site.
Removing pdetransformer from the link leads to the notebook.